### PR TITLE
Bugfix: local variable 'checksum_hex' referenced before assignment

### DIFF
--- a/irods_store.py
+++ b/irods_store.py
@@ -254,14 +254,13 @@ class IrodsManager(object):
             reason = _('paritial write, transfer failed')
             LOG.error(e)
             raise exceptions.StorageWriteDenied(reason)
-        else:
+        finally:
+            self.irods_conn_object.cleanup()
+            file_object=None
             checksum_hex = checksum.hexdigest()
 
             LOG.debug(_("Wrote %(bytes_written)d bytes to %(full_data_path)s, "
                         "checksum = %(checksum_hex)s") % locals())
-        finally:
-            self.irods_conn_object.cleanup()
-            file_object=None
             return [bytes_written, checksum_hex]
 
 


### PR DESCRIPTION
Notes:
- `checksum` is already defined above the `try/except/finally` in L241
- `checksum_hex` is required in order to return the function.
- The only time `checksum_hex` is not required, is when we are raising an Exception (always)

Solution:
- move `checksum_hex` into the `finally:` step prior to returning the result.